### PR TITLE
Expanded fn 'populate_branches' for alternate recipes

### DIFF
--- a/data/src/parser.rs
+++ b/data/src/parser.rs
@@ -158,18 +158,18 @@ fn to_struct(pairs: Vec<pest::iterators::Pair<Rule>>) -> Vec<Reaction> {
                 _ => println!("{:?}", line.as_rule()),
             }
         }
-        let reaction = Recipe::new(id, raw_reagents, Vec::new(), result_amount);
+        let recipe = Recipe::new(id, raw_reagents, Vec::new(), result_amount);
 
         if name.is_empty() && result.is_empty(){
             let old_comp = reactions.pop().unwrap();
-            let new_comp = old_comp.add_recipe(reaction);
+            let new_comp = old_comp.add_recipe(recipe);
             reactions.push(new_comp);
         }else{
             reactions.push(Reaction::new(
                 internal_name,
                 name,
                 result,
-                vec![reaction],
+                vec![recipe],
                 mix_phrase,
                 required_temperature,
                 instant,


### PR DESCRIPTION
Earlier, `populate_branches` was hardcoded to only populate branches with `Compound.recipes[0]`.

Now, it populates all recipes, and the `ChemTreeNode` Struct has been expanded to include Alternate Recipes as well.

To avoid breaking functionality, fn `print_branch` currently only is hardcoded to print only `ChemTreeNode.reagents[0]`.

Suggestion: Split fn `print_branch` into two functions, one for a simple branch without alternate recipes, and one for an expanded branch with all alternate recipes.

Also identified an issue with reagent quantities, which should be expanded to reduce ratios to prevent excess chemicals when crafting.