### PR TITLE
Implemented `search_map` with string permutations

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -4,6 +4,7 @@ use std::io;
 
 use data::chem_tree::{ChemTree, ChemTreeNode};
 use data::chemicals::*;
+use data::search_engine::*;
 use data::fetch::update;
 use data::local::{data_exists, deserialize, serialize};
 use data::parser;
@@ -42,10 +43,11 @@ fn main() {
     //This is a map of all the rection names
     let mut reaction_map: HashMap<String, Reaction> = HashMap::with_capacity(reactions.len());
     let mut result_map: HashMap<String, Vec<String>> = HashMap::with_capacity(reactions.len());
-
+    let mut search_map: HashMap<String, Vec<String>> = HashMap::with_capacity(reactions.len());
     // registers all possible results with their respective internal names
     for reaction in &reactions {
         if !reaction.get_result().is_empty() {
+            search_map = generate_search_keys(search_map, reaction.clone());
             result_map
                 .entry(reaction.get_result())
                 .or_default()
@@ -98,7 +100,7 @@ fn main() {
             let clean = clean_input(user_input.trim().to_string());
 
             //check if result and reaction are same to prevent ignoring alternate recipes seperately defined
-            match result_map.get(&clean) {
+            match search_map.get(&clean) {
                 Some(x) => {
                     if x.len() > 1 {
                         let selection = collision_select(x);
@@ -118,7 +120,7 @@ fn main() {
                     match direct {
                         Some(x) => x.print_dispenser_format(),
                         None => {
-                            let fuzzy = fuzzy_search(&clean, &result_map);
+                            let fuzzy = fuzzy_search(&clean, &search_map);
                             let search_result = compound_trees.get(&fuzzy);
                             match search_result {
                                 Some(x) => x.print_dispenser_format(),

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -3,3 +3,4 @@ pub mod chemicals;
 pub mod fetch;
 pub mod local;
 pub mod parser;
+pub mod search_engine;

--- a/data/src/search_engine.rs
+++ b/data/src/search_engine.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+use crate::chemicals::Reaction;
+
+pub fn generate_search_keys(mut map: HashMap<String, Vec<String>>, reaction: Reaction) -> HashMap<String, Vec<String>> {
+    let internal_name = reaction.get_internal_name();
+    let result = reaction.get_result().to_lowercase();
+    // let name = reaction.get_name().to_lowercase();
+    let mut all_keywords: Vec<String> = Vec::new();
+    all_keywords.append(&mut string_permutations(internal_name.clone()));
+    all_keywords.append(&mut string_permutations(result));
+    // all_keywords.append(&mut string_permutations(name));
+
+    for keyword in all_keywords {
+        map = insert_keyword(map, keyword, &internal_name);
+    }
+
+    map
+}
+
+pub fn insert_keyword(mut map: HashMap<String, Vec<String>>, word: String, internal_name: &String) -> HashMap<String, Vec<String>> {
+    for k in 0..word.len() {
+        match map.get(&word[0..k + 1].to_string()) {
+            Some(array) => {
+                if array.contains(internal_name) {
+                    continue
+                } else {
+                    map
+                        .entry(word[0..k + 1].to_string())
+                        .or_default()
+                        .push(internal_name.to_string());
+                }
+            },
+            None =>  {
+                map
+                    .entry(word[0..k + 1].to_string())
+                    .or_default()
+                    .push(internal_name.to_string());
+            }
+        }
+    }
+    map
+}
+
+pub fn string_permutations(string: String) -> Vec<String> {
+    let mut permmutations: Vec<String> = Vec::new();
+    permmutations.push(string.clone());
+    if string.clone().contains("_") {
+        permmutations.push(string.replace("_", ""));
+        permmutations.push(string.replace("_", " "));
+        for word in string.split("_") {
+            permmutations.push(word.to_string());
+        }
+    }
+    if string.clone().contains(" ") {
+        permmutations.push(string.replace(" ", ""));
+        permmutations.push(string.replace(" ", "_"));
+        for word in string.split(" ") {
+            permmutations.push(word.to_string());
+        }
+    }
+    permmutations
+}


### PR DESCRIPTION
- Created `search_engine.rs`, implementing functions to populate a `search_map`
- `fuzzy_search` use in main now uses `search_map` instead of `result_map`
- Search Map is an alternative HashMap which sorts Reactions by string slices which make up their `internal_name` and `result`. 
- Reactions made up of multiple words (For example `royal_intirobeedril`) can be searched by both their first word `ro->roy->roya=>royal` or their second word `in->intiro->intirobee=>intirobeedril`

**TODO:**
- Sort Reactions by `name` as well, adding support for non-standard characters
- sort by non consecutive strings (`irobe` for `intirobeedril`)
- sort for parts of compound words (`island` for `cocktail_longisland_rcola`), linked to above
