### PR TITLE
Search by Reaction `Name`, Hyphen support

### DIFF
--- a/data/src/search_engine.rs
+++ b/data/src/search_engine.rs
@@ -47,47 +47,48 @@ fn string_permutations(string: String) -> Vec<String> {
     let mut permmutations: Vec<String> = Vec::new();
     permmutations.push(string.clone());
     // Thankfully there are no instances of ["_" and "-" or " "] being in the same name
-    if string.clone().contains("-") && string.clone().contains(" ") {
+    if string.clone().contains("-") || string.clone().contains(" ") {
+        // First, pushes all permutations using "-", "", " ", or "_" as fillers between words
         permmutations.push(string.replace("-", ""));
         permmutations.push(string.replace(" ", ""));
         permmutations.push(string.replace(" ", "").replace("-", ""));
         permmutations.push(string.replace(" ", "-"));
         let only_spaces = string.replace("-", " ");
         permmutations.push(only_spaces.clone());
+        // Uses the last part with " " between words to make accessing each individual word easier
         let mut only_words = only_spaces.split_whitespace(); // split_whitespace works with multiple spaces in a row
-        only_words.next(); // The first word is covered by other permutations
+        only_words.next();
+        // Loop pushes each word individually [Very, High, Fructose, Corn, Syrup], and sets up for inner loop
         loop {
             let word = only_words.next();
             if word == None {
                 return permmutations
             }
-            permmutations.push(word.unwrap().to_string());
-        }
-    } else if string.clone().contains(" ") {
-        permmutations.push(string.replace(" ", ""));
-        permmutations.push(string.replace(" ", "_"));
-        permmutations.push(string.replace(" ", "-"));
-        let mut no_whitespace = string.split_whitespace();
-        no_whitespace.next(); // The first word is covered by other permutations
-        loop {
-            let word = no_whitespace.next();
-            if word == None {
-                return permmutations
+            let word_to_string = word.unwrap().to_string();
+            permmutations.push(word_to_string.clone());
+            let mut clone = only_words.clone();
+            let mut more_words: String = "".to_string();
+            // Inner loop gets all word order permutations, for example [Very Fructose, High Corn, Fructose Syrup]
+            loop {
+                let next = clone.next();
+                if next == None {
+                   break
+                }
+                more_words.push_str(next.unwrap());
+                if &word_to_string != &next.unwrap() {
+                    permmutations.push(format!("{}{}", &word_to_string, &next.unwrap()));
+                    permmutations.push(format!("{} {}", &word_to_string, &next.unwrap()));
+                    permmutations.push(format!("{}-{}", &word_to_string, &next.unwrap()));
+                    permmutations.push(format!("{}_{}", &word_to_string, &next.unwrap()));
+                }
+                if &word_to_string != &more_words {
+                    permmutations.push(more_words.clone());
+                    permmutations.push(format!("{}{}", &word_to_string, &more_words));
+                    permmutations.push(format!("{} {}", &word_to_string, &more_words));
+                    permmutations.push(format!("{}-{}", &word_to_string, &more_words));
+                    permmutations.push(format!("{}_{}", &word_to_string, &more_words));
+                }
             }
-            permmutations.push(word.unwrap().to_string());
-        }
-    } else if string.clone().contains("-") {
-        permmutations.push(string.replace("-", ""));
-        permmutations.push(string.replace("-", "_"));
-        permmutations.push(string.replace("-", " "));
-        let mut no_hyphen = string.split("-");
-        no_hyphen.next(); // The first word is covered by other permutations
-        loop {
-            let word = no_hyphen.next();
-            if word == None {
-                return permmutations
-            }
-            permmutations.push(word.unwrap().to_string());
         }
     }
     if string.clone().contains("_") {
@@ -142,6 +143,7 @@ fn score_diff(searched: &String, input: &String) -> (i32, String) {
         .chars()
         .map(|x| match x {
             '_' => ' ',
+            '-' => ' ',
             _ => x,
         })
         .collect();
@@ -150,6 +152,7 @@ fn score_diff(searched: &String, input: &String) -> (i32, String) {
         .chars()
         .map(|x| match x {
             '_' => ' ',
+            '-' => ' ',
             _ => x,
         })
         .collect();

--- a/data/src/search_engine.rs
+++ b/data/src/search_engine.rs
@@ -46,6 +46,50 @@ fn insert_keyword(mut map: HashMap<String, Vec<String>>, word: String, internal_
 fn string_permutations(string: String) -> Vec<String> {
     let mut permmutations: Vec<String> = Vec::new();
     permmutations.push(string.clone());
+    // Thankfully there are no instances of ["_" and "-" or " "] being in the same name
+    if string.clone().contains("-") && string.clone().contains(" ") {
+        permmutations.push(string.replace("-", ""));
+        permmutations.push(string.replace(" ", ""));
+        permmutations.push(string.replace(" ", "").replace("-", ""));
+        permmutations.push(string.replace(" ", "-"));
+        let only_spaces = string.replace("-", " ");
+        permmutations.push(only_spaces.clone());
+        let mut only_words = only_spaces.split_whitespace(); // split_whitespace works with multiple spaces in a row
+        only_words.next(); // The first word is covered by other permutations
+        loop {
+            let word = only_words.next();
+            if word == None {
+                return permmutations
+            }
+            permmutations.push(word.unwrap().to_string());
+        }
+    } else if string.clone().contains(" ") {
+        permmutations.push(string.replace(" ", ""));
+        permmutations.push(string.replace(" ", "_"));
+        permmutations.push(string.replace(" ", "-"));
+        let mut no_whitespace = string.split_whitespace();
+        no_whitespace.next(); // The first word is covered by other permutations
+        loop {
+            let word = no_whitespace.next();
+            if word == None {
+                return permmutations
+            }
+            permmutations.push(word.unwrap().to_string());
+        }
+    } else if string.clone().contains("-") {
+        permmutations.push(string.replace("-", ""));
+        permmutations.push(string.replace("-", "_"));
+        permmutations.push(string.replace("-", " "));
+        let mut no_hyphen = string.split("-");
+        no_hyphen.next(); // The first word is covered by other permutations
+        loop {
+            let word = no_hyphen.next();
+            if word == None {
+                return permmutations
+            }
+            permmutations.push(word.unwrap().to_string());
+        }
+    }
     if string.clone().contains("_") {
         permmutations.push(string.replace("_", ""));
         permmutations.push(string.replace("_", " "));
@@ -53,20 +97,6 @@ fn string_permutations(string: String) -> Vec<String> {
         no_underscores.next(); // The first word is covered by other permutations
         loop {
             let word = no_underscores.next();
-            if word == None {
-                break
-            }
-            permmutations.push(word.unwrap().to_string());
-        }
-    }
-    if string.clone().contains(" ") {
-        permmutations.push(string.replace(" ", ""));
-        permmutations.push(string.replace(" ", "_"));
-        // Using `string.split_whitespace()` vs `string.split(" ") prevents potential issues with multiple spaces
-        let mut no_whitespace = string.split_whitespace();
-        no_whitespace.next(); // The first word is covered by other permutations
-        loop {
-            let word = no_whitespace.next();
             if word == None {
                 return permmutations
             }

--- a/data/src/search_engine.rs
+++ b/data/src/search_engine.rs
@@ -4,11 +4,11 @@ use crate::chemicals::Reaction;
 pub fn generate_search_keys(mut map: HashMap<String, Vec<String>>, reaction: Reaction) -> HashMap<String, Vec<String>> {
     let internal_name = reaction.get_internal_name();
     let result = reaction.get_result().to_lowercase();
-    // let name = reaction.get_name().to_lowercase();
+    let name = reaction.get_name().to_lowercase();
     let mut all_keywords: Vec<String> = Vec::new();
     all_keywords.append(&mut string_permutations(internal_name.clone()));
     all_keywords.append(&mut string_permutations(result));
-    // all_keywords.append(&mut string_permutations(name));
+    all_keywords.append(&mut string_permutations(name));
 
     for keyword in all_keywords {
         map = insert_keyword(map, keyword, &internal_name);
@@ -17,22 +17,24 @@ pub fn generate_search_keys(mut map: HashMap<String, Vec<String>>, reaction: Rea
     map
 }
 
-pub fn insert_keyword(mut map: HashMap<String, Vec<String>>, word: String, internal_name: &String) -> HashMap<String, Vec<String>> {
+fn insert_keyword(mut map: HashMap<String, Vec<String>>, word: String, internal_name: &String) -> HashMap<String, Vec<String>> {
     for k in 0..word.len() {
-        match map.get(&word[0..k + 1].to_string()) {
+        let chars = word.chars();
+        let string: String = chars.take(k+1).collect();
+        match map.get(&string) {
             Some(array) => {
                 if array.contains(internal_name) {
                     continue
                 } else {
                     map
-                        .entry(word[0..k + 1].to_string())
+                        .entry(string)
                         .or_default()
                         .push(internal_name.to_string());
                 }
             },
             None =>  {
                 map
-                    .entry(word[0..k + 1].to_string())
+                    .entry(string)
                     .or_default()
                     .push(internal_name.to_string());
             }
@@ -41,21 +43,35 @@ pub fn insert_keyword(mut map: HashMap<String, Vec<String>>, word: String, inter
     map
 }
 
-pub fn string_permutations(string: String) -> Vec<String> {
+fn string_permutations(string: String) -> Vec<String> {
     let mut permmutations: Vec<String> = Vec::new();
     permmutations.push(string.clone());
     if string.clone().contains("_") {
         permmutations.push(string.replace("_", ""));
         permmutations.push(string.replace("_", " "));
-        for word in string.split("_") {
-            permmutations.push(word.to_string());
+        let mut no_underscores = string.split("_");
+        no_underscores.next(); // The first word is covered by other permutations
+        loop {
+            let word = no_underscores.next();
+            if word == None {
+                break
+            }
+            permmutations.push(word.unwrap().to_string());
         }
     }
     if string.clone().contains(" ") {
         permmutations.push(string.replace(" ", ""));
         permmutations.push(string.replace(" ", "_"));
-        for word in string.split(" ") {
-            permmutations.push(word.to_string());
+        // Using `string.split_whitespace()` vs `string.split(" ") prevents potential issues with multiple spaces
+        let mut no_whitespace = string.split_whitespace();
+        no_whitespace.next(); // The first word is covered by other permutations
+        loop {
+            let word = no_whitespace.next();
+            if word == None {
+                return permmutations
+            }
+            println!("{}", word.unwrap());
+            permmutations.push(word.unwrap().to_string());
         }
     }
     permmutations

--- a/data/src/search_engine.rs
+++ b/data/src/search_engine.rs
@@ -70,7 +70,6 @@ fn string_permutations(string: String) -> Vec<String> {
             if word == None {
                 return permmutations
             }
-            println!("{}", word.unwrap());
             permmutations.push(word.unwrap().to_string());
         }
     }


### PR DESCRIPTION
- Fixed issue occuring with Reactions with special characters such as `ñ`
- Implemented searching by `name` field, expanding width of searches
- Altered `insert_keyword()` and `string_permutations()` to be private functions
- Altered `string_permutations()` to not redundantly include the first word of multi-word recipes twice
- Altered `string_permutations()` to not include every character for every word, that's `insert_keyword()`'s job
- Thanks to a whopping 3 names having hyphens, support for hyphens was added.
- You can now search using hyphens instead of spaces/underscores
- Searching for words between hyphens is supported (For example, searching `corn` results in Very-High-Fructose Corn Syrup and Corn Syrup)
- Added support for alternate word ordering (For example, searching `fructose syrup` or `high corn`  results in Very-High-Fructose Corn Syrup)
